### PR TITLE
Filter linked libraries from libtool invocation

### DIFF
--- a/ld.py
+++ b/ld.py
@@ -13,7 +13,6 @@ def ld_command(arch, isysroot, library_search_path, linked_libraries, filelist,
         "-syslibroot", isysroot,
         "-L{}".format(library_search_path),
         "-filelist", filelist,
-    ] + ["-l{}".format(x) for x in linked_libraries] + [
         "-o", output,
     ]
 


### PR DESCRIPTION
As far as I know, `libtool` does not accept parameters like `-lz`, `-lsqlite3`, or `-licucore` for static libraries. These are provided when the library is linked into a binary as `OTHER_LDFLAGS`, e.g. `-ObjC -lsqlite3 -lz`.