### PR TITLE
Remove forwarding of `-l` and `-L`

### DIFF
--- a/ld.py
+++ b/ld.py
@@ -4,16 +4,13 @@ import argparse
 import subprocess
 
 
-def ld_command(arch, isysroot, library_search_path, linked_libraries, filelist,
-               output):
+def ld_command(arch, isysroot, filelist, output):
     return [
         "libtool",
         "-static",
         "-arch_only", arch,
         "-syslibroot", isysroot,
-        "-L{}".format(library_search_path),
         "-filelist", filelist,
-    ] + ["-l{}".format(x) for x in linked_libraries] + [
         "-o", output,
     ]
 
@@ -24,17 +21,11 @@ def build_parser():
     parser.add_argument("-isysroot", required=True)
     parser.add_argument("-filelist", required=True)
     parser.add_argument("-o", dest="output", required=True)
-    parser.add_argument("-L", action="append", dest="library_paths",
-                        required=True)
-    parser.add_argument("-l", action="append", dest="linked_libraries",
-                        default=[])
     return parser
 
 if __name__ == "__main__":
     arguments, _ = build_parser().parse_known_args()
     command = ld_command(arguments.arch, arguments.isysroot,
-                         arguments.library_paths[0],
-                         arguments.linked_libraries, arguments.filelist,
-                         arguments.output)
+                         arguments.filelist, arguments.output)
     print(" ".join(command))
     print(subprocess.check_output(command))

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -6,21 +6,16 @@ class TestLd(unittest.TestCase):
     def test_valid_command(self):
         arch = "x86_64"
         syslibroot = "/foo/bar/baz"
-        library_search_path = "/foo/bar/lib"
         filelist = "/foo/filelist.txt"
-        linked_libraries = ["First", "Second"]
         output = "/foo/Executable"
 
-        command = " ".join(ld.ld_command(arch, syslibroot, library_search_path,
-                                         linked_libraries, filelist, output))
+        command = " ".join(ld.ld_command(arch, syslibroot, filelist, output))
         expected_command = " ".join([
             "libtool",
             "-static",
             "-arch_only", "x86_64",
             "-syslibroot", "/foo/bar/baz",
-            "-L/foo/bar/lib",
             "-filelist", "/foo/filelist.txt",
-            "-lFirst", "-lSecond",
             "-o", "/foo/Executable",
         ])
         self.assertEqual(command, expected_command)
@@ -28,19 +23,15 @@ class TestLd(unittest.TestCase):
     def test_no_linked_libraries(self):
         arch = "x86_64"
         syslibroot = "/foo/bar/baz"
-        library_search_path = "/foo/bar/lib"
         filelist = "/foo/filelist.txt"
-        linked_libraries = []
         output = "/foo/Executable"
 
-        command = " ".join(ld.ld_command(arch, syslibroot, library_search_path,
-                                         linked_libraries, filelist, output))
+        command = " ".join(ld.ld_command(arch, syslibroot, filelist, output))
         expected_command = " ".join([
             "libtool",
             "-static",
             "-arch_only", "x86_64",
             "-syslibroot", "/foo/bar/baz",
-            "-L/foo/bar/lib",
             "-filelist", "/foo/filelist.txt",
             "-o", "/foo/Executable",
         ])
@@ -53,16 +44,12 @@ class TestLd(unittest.TestCase):
             "-isysroot", "/foo/bar",
             "-filelist", "/foo/files.txt",
             "-o", "/foo/output",
-            "-L/foo", "-L/bar",
-            "-lFirst", "-lSecond",
         ])
 
         self.assertEqual(arguments.arch, "x86_64")
         self.assertEqual(arguments.isysroot, "/foo/bar")
         self.assertEqual(arguments.filelist, "/foo/files.txt")
         self.assertEqual(arguments.output, "/foo/output")
-        self.assertEqual(arguments.library_paths, ["/foo", "/bar"])
-        self.assertEqual(arguments.linked_libraries, ["First", "Second"])
 
     def test_argument_parser_without_linked_libraries(self):
         parser = ld.build_parser()
@@ -71,12 +58,9 @@ class TestLd(unittest.TestCase):
             "-isysroot", "/foo/bar",
             "-filelist", "/foo/files.txt",
             "-o", "/foo/output",
-            "-L/foo", "-L/bar",
         ])
 
         self.assertEqual(arguments.arch, "x86_64")
         self.assertEqual(arguments.isysroot, "/foo/bar")
         self.assertEqual(arguments.filelist, "/foo/files.txt")
         self.assertEqual(arguments.output, "/foo/output")
-        self.assertEqual(arguments.library_paths, ["/foo", "/bar"])
-        self.assertEqual(arguments.linked_libraries, [])


### PR DESCRIPTION
Looks like for static libraries these are meaningless and the source of
truth for this info is the linker option sections in the `.o` files in
the `ar` archive.